### PR TITLE
Feat/#18 restrict daily point

### DIFF
--- a/src/main/java/com/server/maskara/entity/User.java
+++ b/src/main/java/com/server/maskara/entity/User.java
@@ -41,6 +41,7 @@ public class User implements UserDetails {
     @ElementCollection(fetch = FetchType.EAGER)
     @Builder.Default
     private List<String> roles = new ArrayList<>();
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return this.roles.stream().map(SimpleGrantedAuthority::new).collect(Collectors.toList());
@@ -74,5 +75,9 @@ public class User implements UserDetails {
     @Override
     public boolean isEnabled() {
         return true;
+    }
+
+    public void addPoint(int qty) {
+        this.point += qty;
     }
 }

--- a/src/main/java/com/server/maskara/respository/activityRecord/ActivityRecordRepository.java
+++ b/src/main/java/com/server/maskara/respository/activityRecord/ActivityRecordRepository.java
@@ -5,6 +5,7 @@ import com.server.maskara.entity.ActivityRecord;
 import com.server.maskara.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -18,4 +19,7 @@ public interface ActivityRecordRepository extends JpaRepository<ActivityRecord, 
             "GROUP BY a.residence " +
             "ORDER BY COUNT(a.residence) DESC")
     List<ResidenceRankDto> getResidenceRank();
+
+    @Query("SELECT a FROM ActivityRecord a WHERE a.user = :user AND DATE(a.date) = DATE(NOW())")
+    List<ActivityRecord> getTodayActivity(@Param("user") User user);
 }

--- a/src/main/java/com/server/maskara/service/activityRecord/ActivityRecordService.java
+++ b/src/main/java/com/server/maskara/service/activityRecord/ActivityRecordService.java
@@ -12,7 +12,6 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
@@ -65,5 +64,11 @@ public class ActivityRecordService {
         }
 
         return maskCount;
+    }
+
+    public boolean isFirstActivity(User user) {
+        List<ActivityRecord> optActivityRecord = activityRecordRepository.getTodayActivity(user);
+
+        return optActivityRecord.isEmpty();
     }
 }

--- a/src/main/java/com/server/maskara/service/qr/QrService.java
+++ b/src/main/java/com/server/maskara/service/qr/QrService.java
@@ -3,6 +3,7 @@ package com.server.maskara.service.qr;
 import com.server.maskara.domain.qr.request.RequestQr;
 import com.server.maskara.domain.qr.response.ResponseQr;
 import com.server.maskara.entity.CollectionBox;
+import com.server.maskara.entity.User;
 import com.server.maskara.service.activityRecord.ActivityRecordService;
 import com.server.maskara.service.collectionBox.CollectionBoxService;
 import com.server.maskara.service.user.UserService;
@@ -14,24 +15,29 @@ import java.time.LocalDateTime;
 @Service
 @RequiredArgsConstructor
 public class QrService {
-
     private final UserService userService;
     private final CollectionBoxService collectionBoxService;
     private final ActivityRecordService activityRecordService;
 
     public ResponseQr scanQr(String username, RequestQr requestQr) {
+        User user = userService.findByUsername(username);
+        int earnPoint = 0;
+
+        if (activityRecordService.isFirstActivity(user)) {
+            user.addPoint(1);
+            earnPoint = 1;
+        }
+
         CollectionBox collectionBox = collectionBoxService
                 .getCollectionBoxBySerialNumber(requestQr.getCollectionBoxSerialNumber());
-
-        activityRecordService.createActivityRecord(userService.findByUsername(username),
-                collectionBox, requestQr.getMaskCount());
+        activityRecordService.createActivityRecord(user, collectionBox, requestQr.getMaskCount());
 
         return ResponseQr.builder()
                 .maskCount(requestQr.getMaskCount())
                 .location(collectionBox.getAddress())
                 .date(LocalDateTime.now())
-                .point(1)
-                .sumPoint(userService.updateUserPoint(username))
+                .point(earnPoint)
+                .sumPoint(user.getPoint())
                 .build();
     }
 }

--- a/src/main/java/com/server/maskara/service/user/UserService.java
+++ b/src/main/java/com/server/maskara/service/user/UserService.java
@@ -65,18 +65,4 @@ public class UserService {
         user.setNickName(form.getNickname());
         user.setResidence(form.getResidence());
     }
-
-    @Transactional
-    public int updateUserPoint(String username) {
-        Optional<User> optUser = userRepository.findByUsername(username);
-
-        if (optUser.isEmpty()) {
-            throw new UserNotFoundException();
-        }
-
-        User user = optUser.get();
-        user.setPoint(user.getPoint() + 1);
-
-        return user.getPoint();
-    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ spring.datasource.url=jdbc:mysql://localhost:3306/maskara
 
 spring.jpa.properties.hibernate.show_sql=true
 spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=validate
 logging.level.org.hibernate.sql=debug
 
 jwt.secret=mascara


### PR DESCRIPTION
💡 왜 PR을 하셨나요?

resolve #18 

🤩 개요

하루에 마스크가 여러 차례 수거되어도,
포인트는 한 번만 적립되도록 제한하는 기능을 구현했습니다.

🧑‍💻 작업 사항
ActivityRecord에서 해당 유저의 오늘 날짜 기록을 조회하는 Query Method를 추가했습니다.
조회 결과에 따라 포인트 적립 여부를 달리하도록 구현했습니다.

추가적으로 유저의 포인트를 더하는 것을 User Entity의 메소드로 구현하는 방식으로 변경했습니다.


📖 참고 사항